### PR TITLE
Allow building with unix-2.3

### DIFF
--- a/temporary.cabal
+++ b/temporary.cabal
@@ -25,4 +25,4 @@ Library
     build-depends:   base >= 3 && < 6, filepath >= 1.1 && < 1.3, directory >= 1.0 && < 1.2
     
     if !os(windows)
-        build-depends: unix >= 2.4 && < 2.6
+        build-depends: unix >= 2.3 && < 2.6


### PR DESCRIPTION
This package builds fine with unix version 2.3, which is the version shipped with GHC 6.10. Could you please apply this commit, then cut a new release?
