### PR TITLE
Compatibility with GHC 7.6.1

### DIFF
--- a/Distribution/Compat/TempFile.hs
+++ b/Distribution/Compat/TempFile.hs
@@ -27,7 +27,12 @@ import System.IO              (Handle, openTempFile, openBinaryTempFile)
 import Data.Bits              ((.|.))
 import System.Posix.Internals (c_open, c_close, o_CREAT, o_EXCL, o_RDWR,
                                o_BINARY, o_NONBLOCK, o_NOCTTY)
-import System.IO.Error        (try, isAlreadyExistsError)
+import System.IO.Error        (isAlreadyExistsError)
+#if __GLASGOW_HASKELL__ >= 706
+import Control.Exception      (try)
+#else
+import System.IO.Error        (try)
+#endif
 #if __GLASGOW_HASKELL__ >= 611
 import System.Posix.Internals (withFilePath)
 #else

--- a/temporary.cabal
+++ b/temporary.cabal
@@ -25,4 +25,4 @@ Library
     build-depends:   base >= 3 && < 6, filepath >= 1.1 && < 1.4, directory >= 1.0 && < 1.2
     
     if !os(windows)
-        build-depends: unix >= 2.3 && < 2.6
+        build-depends: unix >= 2.3 && < 2.7


### PR DESCRIPTION
Increment upper bound on unix dependency and import 'try' from Control.Exception if using GHC 7.6.1 instead of System.IO.Error.
