### PR TITLE
Adds a canonicalised version of withSystemTempDirectory

### DIFF
--- a/temporary.cabal
+++ b/temporary.cabal
@@ -1,5 +1,5 @@
 name:                temporary
-version:             1.2.0.3
+version:             1.2.0.4
 cabal-version:       >= 1.6
 synopsis:            Portable temporary file and directory support for Windows and Unix, based on code from Cabal
 description:         The functions for creating temporary files and directories in the base library are quite limited. The unixutils


### PR DESCRIPTION
This relates to a reported issue with stack that uses this library:

https://github.com/commercialhaskell/stack/issues/1017

And provides a preferred fix in place of a previous stack pull
request:

https://github.com/commercialhaskell/stack/pull/1019