### PR TITLE
Simple functions that don't need passing around handles, only filenames or file contents

### DIFF
--- a/System/IO/Temp.hs
+++ b/System/IO/Temp.hs
@@ -2,7 +2,7 @@ module System.IO.Temp (
     withSystemTempFile, withSystemTempDirectory,
     withTempFile, withTempDirectory,
     module Distribution.Compat.TempFile,
-    writeTempFile
+    writeTempFile, writeSystemTempFile
   ) where
 
 -- NB: this module was extracted directly from "Distribution/Simple/Utils.hs"
@@ -82,8 +82,8 @@ withTempDirectory targetDir template =
     (liftIO . ignoringIOErrors . removeDirectoryRecursive)
 
 
--- | Create a unique new file, write a given data string to it, and
---   close the handle again. The file will not be deleted automatically,
+-- | Create a unique new file, write (text mode) a given data string to it,
+--   and close the handle again. The file will not be deleted automatically,
 --   and only the current user will have permission to access the file
 --   (see `openTempFile` for details).
 writeTempFile :: FilePath    -- ^ Directory in which to create the file
@@ -95,6 +95,12 @@ writeTempFile targetDir template content = Exception.bracket
     (\(_, handle) -> hClose handle)
     (\(filePath, handle) -> hPutStr handle content >> return filePath)
 
+-- | Like 'writeTempFile', but use the system directory for temporary files.
+writeSystemTempFile :: String      -- ^ File name template.
+                    -> String      -- ^ Data to store in the file.
+                    -> IO FilePath -- ^ Path to the (written and closed) file.
+writeSystemTempFile template content
+    = getTemporaryDirectory >>= \tmpDir -> writeTempFile tmpDir template content
 
 
 ignoringIOErrors :: MonadCatch m => m () -> m ()


### PR DESCRIPTION
The `withTempFile` functions are useful for serious work with file handles, but this is awkward if all you want to do is dump some data and be sure you don't overwrite anything. `writeTempFile` now does just that.

Furthermore: not always can you actually generate a file from within Haskell, like `openTempFile` prepares for us.  Sometimes, the actual file must be generated by an external library- or even process call, which can't use handles but just needs a target file name. I added a function which only uses the functionality to generate such unique-new file names, but doesn't actually generate any files, relegating this to a supplied action.

(Actually the implementation is a bit more hackish: it generates a temporary file with `openTempFile`, immediately deletes it and uses the file name for whatever the user needs it to.
